### PR TITLE
Add test for single workflow file

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -85,6 +85,16 @@ jobs:
           app-id: "${{ secrets.APPID }}"
           app-install-id: "${{ secrets.APPINSTALLID }}"
           app-private-key: "${{ secrets.APPPRIVATEKEY }}"
+ 
+  get-dora-single:
+        uses: ayodejiayodele/dora/.github/workflows/deployment-frequency.yml@main
+        with:
+          owner: "samsmithnz"
+          repo: "SamsFeatureFlags"
+          workflowName: "Feature Flags CI/CD"
+          numberOfDays: 30
+        secrets:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           
   releaseAction:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If this PR is merged, it will add one more test job to the `workflow.yml` testing workflow.

The test parameters are exactly the same as one of the other previous test jobs already existing in the same workflow file. 

As mentioned, I have created a DORA metrics workflow for `Deployment Frequency` and `Lead Time for Changes`, which takes a single workflow as input and then generates a fine summary as in this [example](https://github.com/ayodejiayodele/dora/actions/runs/3124228481) using the [reusable workflow](https://github.com/ayodejiayodele/dora/blob/main/.github/workflows/deployment-frequency.yml).

