### PR TITLE
Change Elite badge to bright green colour

### DIFF
--- a/src/deploymentfrequency.ps1
+++ b/src/deploymentfrequency.ps1
@@ -180,7 +180,7 @@ function Main ([string] $ownerRepo,
     elseif ($deploymentsPerDay -gt $dailyDeployment) 
     {
         $rating = "Elite"
-        $color = "green"
+        $color = "brightgreen"
         $displayMetric = [math]::Round($deploymentsPerDay,2)
         $displayUnit = "per day"
     }


### PR DESCRIPTION
This change will display a bright green badge colour for the `Elite` category rather than the lemon green being used for both Elite and High previously.